### PR TITLE
Fix Dockerfile to use venv and pin Ubuntu version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
     python3 \
@@ -21,10 +23,13 @@ RUN apt-get update && apt-get install -y \
     fonts-liberation\
     && rm -rf /var/lib/apt/lists/*
 
+WORKDIR /app
+
+RUN python3 -m venv /app/venv
+ENV PATH="/app/venv/bin:$PATH"
+
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
-
-WORKDIR /app
 
 COPY app .
 COPY /Configs/policy.xml /etc/ImageMagick-6/policy.xml

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
     hostname: ollama
     container_name: Tiktokker
     build: ./
-    command: ollama serve && ollama pull llama2-uncensored
+    command: bash -c "ollama serve & sleep 5 && ollama pull llama2-uncensored && wait"
     volumes:
       - ollama:/app
     deploy:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,9 +2,8 @@ moviepy
 numpy
 langchain
 requests
-shutils
 pytube
 Cython
 dtw-python
 openai-whisper
-whisper-timstamped
+whisper-timestamped


### PR DESCRIPTION
- Pin to ubuntu:22.04 to avoid PEP 668 externally-managed-environment errors that break bare pip install on ubuntu:latest (24.04+)
- Create a Python venv and add it to PATH so pip works correctly
- Move WORKDIR before COPY so requirements.txt lands in /app
- Add DEBIAN_FRONTEND=noninteractive to prevent apt prompts
- Fix docker-compose command: background ollama serve so ollama pull can actually run
- Remove non-existent shutils package from requirements.txt
- Fix whisper-timstamped typo -> whisper-timestamped

https://claude.ai/code/session_01VfEBNzBDGWMVKCsHgcEg11